### PR TITLE
Generalize linking of Fortran runtime to support different compilers.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,6 @@
 ## With Rcpp 0.11.0 and later, we no longer need to set PKG_LIBS as there is
 ## no user-facing library. The include path to headers is already set by R.
-PKG_LIBS = -lblas -lgfortran -llapack -lquadmath
+PKG_LIBS = -lblas -llapack $(FLIBS)
 
 ## With R 3.1.0 or later, you can uncomment the following line to tell R to 
 ## enable compilation with C++11 (or even C++14) where available


### PR DESCRIPTION
Fixes the linking on Windows to query R for the Fortran runtime libraries for the Fortran compiler in use, rather than hard-coding gfortran. This is needed to build the package for Windows/aarch64 using LLVM/flang.